### PR TITLE
Heroku configuration requirements

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn myproject.wsgi

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn myproject.wsgi
+web: gunicorn litewatch.wsgi

--- a/litewatch/settings.py
+++ b/litewatch/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-d9#=!26mrxd*3v!iy)6263_^r$f+a7w8-%@9z#7l7nbw9=wnfk
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = [litewatch.herokuapp.com]
+ALLOWED_HOSTS = ['litewatch.herokuapp.com']
 
 
 # Application definition

--- a/litewatch/settings.py
+++ b/litewatch/settings.py
@@ -117,7 +117,12 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
-STATIC_URL = 'static/'
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
+STATIC_URL = '/static/'
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, 'static'),
+)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/litewatch/settings.py
+++ b/litewatch/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'django-insecure-d9#=!26mrxd*3v!iy)6263_^r$f+a7w8-%@9z#7l7nbw9=wnfk
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [litewatch.herokuapp.com]
 
 
 # Application definition

--- a/litewatch/settings.py
+++ b/litewatch/settings.py
@@ -117,12 +117,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
 
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATIC_URL = '/static/'
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
-)
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.9.1
 lxml==4.5.2
 requests==2.28.1
 django==4.1
+gunicorn==20.1.0


### PR DESCRIPTION
Settings required to make the project deploy and start in Heroku. Does not include static file support as this was disabled in Heroku (multiple steps required if static support is desired).